### PR TITLE
Use internal references to access pdf generator

### DIFF
--- a/.kube.yaml
+++ b/.kube.yaml
@@ -21,7 +21,7 @@
       name: asl-dev-auth
       key: secret
     API_URL: https://public-api.notprod.asl.homeoffice.gov.uk
-    PDF_SERVICE: https://pdf-generator.notprod.asl.homeoffice.gov.uk/convert
+    PDF_SERVICE: https://pdf-generator:10443/convert
 
 - name: pdf-generator
   recipe: webapp

--- a/lib/pdf.js
+++ b/lib/pdf.js
@@ -1,4 +1,8 @@
 const fetch = require('r2');
+const https = require('https');
+const agent = new https.Agent({
+  rejectUnauthorized: false
+});
 
 module.exports = settings => {
   return (req, res, next) => {
@@ -12,6 +16,7 @@ module.exports = settings => {
         if (err) return next(err);
         return fetch
           .post(settings.pdf, {
+            agent,
             json: {
               template: html,
               pdfOptions: {


### PR DESCRIPTION
We don't need to go out to the internet to com back into a pod in the same namespace. Instead use internal hostname for local pod.