### PR TITLE
Wrap default layout in a screen only helper

### DIFF
--- a/views/layouts/app.jsx
+++ b/views/layouts/app.jsx
@@ -2,7 +2,6 @@ const React = require('react');
 const { pick } = require('lodash');
 const { Provider } = require('react-redux');
 const Layout = require('./default');
-const Pdf = require('./pdf');
 
 const createStore = require('../../src/create-store');
 
@@ -18,10 +17,7 @@ const App = props => {
   const store = createStore(data, { filterBy, textFilter, pdf });
   return (
     <Provider store={ store }>
-      { pdf
-        ? <Pdf>{ children }</Pdf>
-        : <Layout { ...props } data={ data }>{ children }</Layout>
-      }
+      <Layout { ...props } data={ data }>{ children }</Layout>
     </Provider>
   );
 };

--- a/views/layouts/default.jsx
+++ b/views/layouts/default.jsx
@@ -4,6 +4,9 @@ const PhaseBanner = require('govuk-react-components/components/phase-banner');
 
 const Breadcrumb = require('../components/breadcrumb');
 
+const ScreenOnly = require('../helpers/screen-only');
+const Pdf = require('./pdf');
+
 const Layout = ({
   children,
   propositionHeader,
@@ -33,4 +36,4 @@ const Layout = ({
   </GovUK>
 );
 
-module.exports = Layout;
+module.exports = ScreenOnly(Layout, Pdf);


### PR DESCRIPTION
Default layout only renders on screen, and falls back to the pdf layout when in a PDF rendering context