### PR TITLE
Fix kube deploy tokens for different environments

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -74,17 +74,33 @@ pipeline:
   dev_deploy:
     image: quay.io/ukhomeofficedigital/kd:v0.5.0
     environment:
-      KUBE_NAMESPACE: asl-${DRONE_DEPLOY_TO}
+      KUBE_NAMESPACE: asl-dev
       INSECURE_SKIP_TLS_VERIFY: "TRUE"
     secrets:
       - kube_server
-      - kube_token
+      - kube_token_dev
+    environment:
+      KUBE_TOKEN: $${KUBE_TOKEN_DEV}
     commands:
       - kd -f deploy
     when:
-      environment:
-        - dev
-        - preprod
+      environment: dev
+      event: deployment
+
+  preprod_deploy:
+    image: quay.io/ukhomeofficedigital/kd:v0.5.0
+    environment:
+      KUBE_NAMESPACE: asl-preprod
+      INSECURE_SKIP_TLS_VERIFY: "TRUE"
+    secrets:
+      - kube_server
+      - kube_token_preprod
+    environment:
+      KUBE_TOKEN: $${KUBE_TOKEN_PREPROD}
+    commands:
+      - kd -f deploy
+    when:
+      environment: preprod
       event: deployment
 
 matrix:


### PR DESCRIPTION
dev and preprod namespaces use different tokens to deploy with. Nee to reflect this in the deployment config