### PR TITLE
Ignore .babelrc in Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@ deploy
 node_modules
 tests
 assets
+.babelrc


### PR DESCRIPTION
If a .babelrc file exists, then the require-register that express-react-views uses to compile jsx at require time will use it. _But_ it specifies dependencies that are only listed as dev, and so don't exist in Docker-land. This means rendering templates fails.

By ignoring the .babelrc in Docker, then only the default babel-plugins are used, which are included as dependencies of express-react-views.