### PR TITLE
Notify failed deployments

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -121,6 +121,7 @@ pipeline:
         `{{build.message}}`
       {{/success}}
     when:
+      status:  [ failure, success ]
       event: deployment
       environment:
         - dev


### PR DESCRIPTION
We have slack notifications enabled, but they onyl run for successes, and failures is probably more important to be notified about.