### PR TITLE
Add npm audit to ci pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5,7 +5,8 @@ pipeline:
     secrets:
       - npm_auth_token
     commands:
-      - npm install
+      - npm install -g npm@6
+      - npm ci
       - npm test
     when:
       event: [push, pull_request, tag]
@@ -15,6 +16,7 @@ pipeline:
     secrets:
       - npm_auth_token
     commands:
+      - npm install -g npm@6
       - npx @lennym/ciaudit
     when:
       event: [push, pull_request, tag]

--- a/.drone.yml
+++ b/.drone.yml
@@ -10,6 +10,15 @@ pipeline:
     when:
       event: [push, pull_request, tag]
 
+  audit:
+    image: node:8
+    secrets:
+      - npm_auth_token
+    commands:
+      - npx @lennym/ciaudit
+    when:
+      event: [push, pull_request, tag]
+
   compile:
     image: node:8
     secrets:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,12 @@ FROM quay.io/ukhomeofficedigital/nodejs-base:v8
 ARG NPM_AUTH_USERNAME
 ARG NPM_AUTH_TOKEN
 
+RUN npm install -g npm@6
+
 COPY .npmrc /app/.npmrc
 COPY package.json /app/package.json
 COPY package-lock.json /app/package-lock.json
-RUN npm install --production --no-optional
+RUN npm ci --production --no-optional
 COPY . /app
 
 RUN rm /app/.npmrc


### PR DESCRIPTION
I have created a wrapper for it, because `npm audit` itself _always_ fails if _any_ vulnerabilities are present, and we don't want to fail on low or moderate vulnerabilities. This issue has been PR'ed in npm, so if/when https://github.com/npm/cli/pull/31 is merged and released then the command can be swapped for a basic `npm audit`.