### PR TITLE
Fix functional tests around people pages

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -120,7 +120,7 @@ pipeline:
       - aws_secret
     commands:
       - npm install
-      - npm run test:functional -- --suite smoke
+      - npm run test:functional
     when:
       event: deployment
       environment:

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha1-oaK4axlNOaArI0+RblmPPwsMeG0="
     },
     "@asl/pages": {
-      "version": "5.0.0",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/pages/-/@asl/pages-5.0.0.tgz",
-      "integrity": "sha1-AzAAAaCL+gucjzL8AA/aHZjzy1U=",
+      "version": "5.0.1",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/pages/-/@asl/pages-5.0.1.tgz",
+      "integrity": "sha1-8X1UPnKkpMo+GVAPZlS8fsTfiIU=",
       "requires": {
         "@asl/dictionary": "^1.1.1",
         "babel-plugin-transform-object-rest-spread": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/UKHomeOffice/asl#readme",
   "dependencies": {
-    "@asl/pages": "^5.0.0",
+    "@asl/pages": "^5.0.1",
     "@asl/service": "^4.1.0",
     "lodash": "^4.17.10"
   },

--- a/tests/functional/specs/people-list.js
+++ b/tests/functional/specs/people-list.js
@@ -8,6 +8,8 @@ describe('People directory', () => {
 
     browser.$('.link-filter').$('a=NACWO').click();
 
+    browser.waitForExist('table:not(.loading)');
+
     const roles = browser.$$('tbody tr td:nth-child(2)')
       .map(td => browser.elementIdText(td.ELEMENT).value);
 
@@ -20,6 +22,8 @@ describe('People directory', () => {
 
     browser.$('.search-box input[type="text"]').setValue('Laur');
     browser.$('.search-box button').click();
+
+    browser.waitForExist('table:not(.loading)');
 
     const names = browser.$$('tbody tr td:nth-child(1)')
       .map(td => browser.elementIdText(td.ELEMENT).value);
@@ -35,6 +39,8 @@ describe('People directory', () => {
 
     browser.$('.search-box input[type="text"]').setValue('b');
     browser.$('.search-box button').click();
+
+    browser.waitForExist('table:not(.loading)');
 
     const roles = browser.$$('tbody tr td:nth-child(2)')
       .map(td => browser.elementIdText(td.ELEMENT).value);


### PR DESCRIPTION
Some of these were just race conditions with ajax loading paginated data, but one flagged a genuine bug, which had gone unnoticed. As such (and because they don't take a long time to run) remove the smoke test filter in CI, so all tests will now run against a deployment.

The bug will need https://github.com/UKHomeOffice/asl-public-api/pull/41 to be deployed before the tests pass.