### PR TITLE
Add failure messages to test assertions

### DIFF
--- a/tests/functional/specs/people-list.js
+++ b/tests/functional/specs/people-list.js
@@ -48,8 +48,8 @@ describe('People directory', () => {
     const names = browser.$$('tbody tr td:nth-child(1)')
       .map(td => browser.elementIdText(td.ELEMENT).value);
 
-    roles.forEach(role => assert.ok(role.includes('NACWO')));
-    names.forEach(name => assert.ok(name.toLowerCase().includes('b')));
+    roles.forEach(role => assert.ok(role.includes('NACWO'), `${role} should contain "NACWO"`));
+    names.forEach(name => assert.ok(name.toLowerCase().includes('b'), `${name} should contain "b"`));
   });
 
 });


### PR DESCRIPTION
Otherwise failures are output as `AssertionError [ERR_ASSERTION]: false == true` which isn't very useful for working out what's gone wrong.