### PR TITLE
Add README documentation

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,2 +1,8 @@
 extends:
   - lennym
+
+plugins:
+  - undocumented-env
+
+rules:
+  undocumented-env/no-undocumented: error

--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
 # asl
+
+## About
+
+The establishment facing UI for managing licences
+
+## Dependencies
+
+* `@asl/service/ui` provides the common ui boilerplate - auth, sessions, static asset serving, CSP etc.
+* `@asl/pages` provides the react components for the pages and layouts
+
+## Configuration
+
+The service can be configured for local development by setting environment variables in a `.env` file.
+
+The following environment variables are required:
+
+* `API_URL` - the hostname of the downstream API service
+* `SESSION_SECRET` - an arbitrary string used to sign session data
+* `KEYCLOAK_REALM` - the keycloak realm used for authentication
+* `KEYCLOAK_URL` - the url of the keycloak server
+* `KEYCLOAK_CLIENT` - the client name used to authenticate with keycloak
+* `KEYCLOAK_SECRET` - the secret used to authenticate with the keycloak client
+
+The following environment variables can be optionally defined:
+
+* `PORT` - port that the service will listen on - default `8080`
+* `REDIS_HOST` - host of the redis server used for session storage - default `localhost`
+* `REDIS_PORT` - port of the redis server used for session storage - default `6379`
+* `REDIS_PASSWORD` - password of the redis server used for session storage - default `undefined`
+
+
+## Connected services
+
+### Upstream
+
+None
+
+### Downstream
+
+The following services must be available in order to run:
+
+* `asl-public-api` - to access licence data
+* `redis` - to store serialised session data

--- a/README.md
+++ b/README.md
@@ -2,7 +2,21 @@
 
 ## About
 
-The establishment facing UI for managing licences
+Web server serving the establishment facing UI for managing licences
+
+## Usage
+
+To run a local instance:
+
+```
+npm run dev
+```
+
+To rebuild js and css assets:
+
+```
+npm run build
+```
 
 ## Dependencies
 
@@ -42,3 +56,51 @@ The following services must be available in order to run:
 
 * `asl-public-api` - to access licence data
 * `redis` - to store serialised session data
+
+## Development
+
+Very little code actually resides in this repo, so development is most likely to occur on one of the dependent modules.
+
+### Using linked modules
+
+To link a local development version of a dependency - in this example `@asl/pages`:
+
+```bash
+# in the module's directory - e.g. ~/dev/asl-pages
+npm link
+
+# in this project's directory
+npm link @asl/pages
+```
+
+This will then use your local version of `@asl/pages` when you `require('@asl/pages')`.
+
+_Note: if you run `npm install [pkg]` then this will undo the linking and revert to the npm registry version, so you will need to re-execute the second command above._
+
+### Watching dependencies
+
+If you are working in a linked version of `@asl/pages` you will likely need to recompile js assets when you make changes. To do this run:
+
+```
+npm run build:js -- --watch
+```
+
+To force the server to restart on changes watch your linked directory:
+
+```
+npm run dev -- -w ../path/to/asl-pages
+```
+
+### Testing
+
+To run basic tests including eslint and unit tests:
+
+```
+npm test
+```
+
+To run the full functional test suite in an automated browser:
+
+```
+npm run test:functional:local
+```

--- a/config.js
+++ b/config.js
@@ -1,7 +1,6 @@
 module.exports = {
   port: process.env.PORT || 8080,
   api: process.env.API_URL,
-  pdf: process.env.PDF_SERVICE,
   session: {
     secret: process.env.SESSION_SECRET,
     host: process.env.REDIS_HOST,

--- a/package-lock.json
+++ b/package-lock.json
@@ -3277,6 +3277,15 @@
       "integrity": "sha512-fVcdyuKRr0EZ4fjWl3c+gp1BANFJD1+RaWa2UPYfMZ6jCtp5RG00kSaXnK/dE5sYzt4kaWJ9qdxqUfc0d9kX0w==",
       "dev": true
     },
+    "eslint-plugin-undocumented-env": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-undocumented-env/-/eslint-plugin-undocumented-env-1.0.0.tgz",
+      "integrity": "sha512-GQYhxiUBp1804Q5MTzUlY0iMl3vSILPzd1W51x0aa6sUs0okrCaxM5hNgyT/w4CbMcRSJtzXYCFut6SaU+7atg==",
+      "dev": true,
+      "requires": {
+        "findup": "^0.1.5"
+      }
+    },
     "eslint-scope": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "dev": "nodemon -r dotenv/config",
+    "dev": "nodemon -r dotenv/config -e js,jsx,json -w .",
     "test": "npm run test:lint",
     "test:lint": "eslint .",
     "test:functional": "asl-test ./tests/functional/config",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "dotenv": "^5.0.1",
     "eslint": "^4.15.0",
     "eslint-config-lennym": "^2.0.1",
+    "eslint-plugin-undocumented-env": "^1.0.0",
     "funkie": "0.0.6",
     "funkie-chromedriver": "0.0.1",
     "nodemon": "^1.17.4",


### PR DESCRIPTION
* Add initial framework for service documentation
* Remove some redundant configuration from `config.js`
* Add `eslint-plugin-undocumented-env` to ensure configuration variables are documented where used