### PR TITLE
Improve reliability of some test failures

### DIFF
--- a/tests/functional/config.js
+++ b/tests/functional/config.js
@@ -12,6 +12,9 @@ module.exports = env => ({
     preprod: 'https://public-ui.preprod.asl.homeoffice.gov.uk'
   },
   wdio: {
+    mochaOpts: {
+      timeout: 60000
+    },
     suites: {
       smoke: ['./tests/functional/specs/smoke-tests.js']
     }

--- a/tests/functional/specs/people-list.js
+++ b/tests/functional/specs/people-list.js
@@ -44,6 +44,8 @@ describe("People directory", () => {
       .$("a=NACWO")
       .click();
 
+    browser.waitForExist("table:not(.loading)");
+
     browser.$('.search-box input[type="text"]').setValue("b");
     browser.$(".search-box button").click();
 


### PR DESCRIPTION
The people filters test was failing sporadically because it was firing too many requests at the server in a short period of time, so the order of response wasn't reliable. By adding a wait between the two interactions we can be sure of the response order.

Also increase the overall timeout as some test suites were taking longer than the default timeout on my machine.