### PR TITLE
Fix functional tests for profile pages

### DIFF
--- a/tests/functional/specs/edit-profile.js
+++ b/tests/functional/specs/edit-profile.js
@@ -1,0 +1,36 @@
+const assert = require('assert');
+
+describe('Smoke tests', () => {
+
+  it('can access profile edit form', () => {
+
+    browser.withUser('holc');
+    browser
+      .$('header .status-bar')
+      .$('a=Leonard Martin')
+      .click();
+    browser
+      .$('a=Edit your details')
+      .click();
+
+    browser.setValue('input[name=firstName]', 'Leonardo');
+    browser.$('button*=Submit').click();
+
+    let notification = browser.$('#notification-summary-heading').getText();
+    assert.equal(notification, 'Profile edited');
+
+    let name = browser.getText('header .status-bar a');
+    assert.equal(name[0], 'Leonardo Martin');
+
+    browser.setValue('input[name=firstName]', 'Leonard');
+    browser.$('button*=Submit').click();
+
+    notification = browser.$('#notification-summary-heading').getText();
+    assert.equal(notification, 'Profile edited');
+
+    name = browser.getText('header .status-bar a');
+    assert.equal(name[0], 'Leonard Martin');
+
+  });
+
+});

--- a/tests/functional/specs/smoke-tests.js
+++ b/tests/functional/specs/smoke-tests.js
@@ -50,10 +50,36 @@ describe('Smoke tests', () => {
     browser.withUser('holc');
     browser
       .click('a=University of Croydon')
-      .click('=Establishment details')
-      .click('=Leonard Martin');
+      .click('a=Establishment details');
+    browser
+      .$('main dl')
+      .$('a=Leonard Martin')
+      .click();
     const title = browser.getText('h1');
     assert.equal(title, 'Leonard Martin');
+  });
+
+  it('can access account management page', () => {
+    browser.withUser('holc');
+    browser
+      .$('header .status-bar')
+      .$('a=Leonard Martin')
+      .click();
+    const title = browser.getText('h1');
+    assert.equal(title, 'Your account');
+  });
+
+  it('can access profile edit form', () => {
+    browser.withUser('holc');
+    browser
+      .$('header .status-bar')
+      .$('a=Leonard Martin')
+      .click();
+    browser
+      .$('a=Edit your details')
+      .click();
+    const title = browser.getText('h1');
+    assert.equal(title, 'Edit profile');
   });
 
   it('can access schedule of premises page', () => {


### PR DESCRIPTION
Link in header now links to account mangement section and not a user profile, so tests which look for a profile page need to click body links instead.

Add further tests for account management page