### PR TITLE
Increase size limit on body-parser

### DIFF
--- a/pages/project-versions/update/index.js
+++ b/pages/project-versions/update/index.js
@@ -34,7 +34,7 @@ module.exports = settings => {
     next();
   });
 
-  app.put('/', bodyParser.json());
+  app.put('/', bodyParser.json({ limit: '5mb' }));
 
   app.put('/', (req, res, next) => {
     const opts = {


### PR DESCRIPTION
The default limit is 100kb, which is exceeded for a complete PPL application. Set to 5mb.