### PR TITLE
Use correct parameter for project save url builder

### DIFF
--- a/pages/project-versions/update/index.js
+++ b/pages/project-versions/update/index.js
@@ -36,7 +36,7 @@ module.exports = settings => {
         }
       }
     };
-    req.api(`/establishments/${req.establishmentId}/projects/${req.projectId}/project-versions/${req.model.id}/patch`, opts)
+    req.api(`/establishments/${req.establishmentId}/projects/${req.projectId}/project-versions/${req.version.id}/patch`, opts)
       .then(() => res.json({}))
       .catch(next);
   });


### PR DESCRIPTION
This is throwing an error right now because `req.model` is undefined. Should be `req.version`.