### PR TITLE
Destroy session when redirecting to internal-ui

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -26,6 +26,7 @@ module.exports = settings => {
 
   app.use((req, res, next) => {
     if (settings.internalUrl && get(req, 'user.profile.asruUser')) {
+      req.session.destroy();
       return res.redirect(settings.internalUrl);
     }
     next();


### PR DESCRIPTION
This prevents the session store on the public service from thinking you're still an internal user if you return.