### PR TITLE
Use asl-base docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,11 @@
-FROM node:10-alpine
+FROM quay.io/ukhomeofficedigital/asl-base:v1
 
 ARG NPM_AUTH_USERNAME
 ARG NPM_AUTH_TOKEN
 
 RUN apk upgrade --no-cache
-RUN addgroup -S app
-RUN adduser -S app -G app -u 999 -h /app/
-RUN chown -R app:app /app/
 
 USER 999
-WORKDIR /app
 
 COPY .npmrc /app/.npmrc
 COPY package.json /app/package.json


### PR DESCRIPTION
This means that we use a known and controlled base image for our services instead of pulling an unknown image from docker-hub at build/deploy time