### PR TITLE
Don't send separate API calls on project submission

### DIFF
--- a/pages/project-versions/submit/index.js
+++ b/pages/project-versions/submit/index.js
@@ -34,7 +34,7 @@ module.exports = settings => {
         comment
       }
     };
-    req.api(`/establishments/${req.establishmentId}/projects/${req.projectId}/project-versions/${req.versionId}/submit`, { method: 'POST' })
+    Promise.resolve()
       .then(() => req.api(`/establishments/${req.establishmentId}/projects/${req.projectId}/grant`, { method: 'POST', json }))
       .then(() => res.redirect(req.buildRoute('project.version.success')))
       .catch(next);


### PR DESCRIPTION
Performing two API calls to complete the single action of a project submission is fragile and liable to cause inconsistent data. Instead perform the data updates that were a result of the project version submission as part of the grant call on the project.