### PR TITLE
Fix initial state for project patching

### DIFF
--- a/pages/project-versions/update/js/index.js
+++ b/pages/project-versions/update/js/index.js
@@ -4,6 +4,7 @@ import { updateSavedProject } from '@asl/projects/client/actions/projects';
 import debounce from 'lodash/debounce';
 import fetch from 'r2';
 import cloneDeep from 'lodash/cloneDeep';
+import isEmpty from 'lodash/isEmpty';
 import { diff, applyChange } from 'deep-diff';
 
 const updateProject = project => {
@@ -55,8 +56,10 @@ const onUpdate = props => {
   return (dispatch, getState) => {
     const { project, savedProject } = getState();
     const newState = { ...project, ...props };
+
     dispatch(updateProject(newState));
-    const patch = diff(savedProject, newState);
+    const before = isEmpty(savedProject) ? project : savedProject;
+    const patch = diff(before, newState);
     return postData(patch, getState, dispatch);
   };
 };


### PR DESCRIPTION
When a project first loads there is no saved state, and so the first diff following a page load is always _the entire project_.

This results in a very large payload - in some cases overwhelming the maximum body size.

In the case where there is no saved project state then use the project data instead as the basis for the first diff. This results in a zero diff for the first sync, as expected.