### PR TITLE
Make invitations more prominent on dashboard

### DIFF
--- a/pages/dashboard/views/index.jsx
+++ b/pages/dashboard/views/index.jsx
@@ -24,14 +24,14 @@ const Index = ({ profile }) => (
     <Header
       title={<Snippet name={profile.firstName}>pages.dashboard.greeting</Snippet>}
     />
-    <h3><Snippet>pages.dashboard.tasks</Snippet></h3>
-    <TaskList />
     {
       !!profile.invitations.length && <Fragment>
-        <h3>Pending Invitations</h3>
+        <h2>{profile.invitations.length} pending invitation{profile.invitations.length === 1 ? '' : 's'}</h2>
         <PanelList panels={profile.invitations.map(invitation => <Invitation key={invitation.id} establishment={ invitation.establishment.name } token={invitation.token} />)}/>
       </Fragment>
     }
+    <h3><Snippet>pages.dashboard.tasks</Snippet></h3>
+    <TaskList />
     {
       !!profile.establishments.length && <Fragment>
         <h3>Establishments</h3>


### PR DESCRIPTION
Moves the invitations content to the top of the screen so it can't be so easily missed. Also make the heading an `h2` instead of an `h3` so it _really_ can't be missed.