### PR TITLE
Only refresh profile if cache disabled

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -66,6 +66,15 @@ module.exports = settings => {
     });
   });
 
+  app.use((req, res, next) => {
+    if (req.get('pragma') === 'no-cache') {
+      return req.user.refreshProfile()
+        .then(() => next())
+        .catch(next);
+    }
+    next();
+  });
+
   app.use(urls.dashboard, dashboard());
 
   // add "home" breadcrmb to every subsequent page

--- a/pages/dashboard/index.js
+++ b/pages/dashboard/index.js
@@ -8,11 +8,6 @@ module.exports = settings => {
   });
 
   app.get('/', (req, res, next) => {
-    req.user.refreshProfile()
-      .then(() => next())
-      .catch(next);
-  },
-  (req, res, next) => {
     res.locals.static.profile = req.user.profile;
     next();
   });


### PR DESCRIPTION
Previously the user profile that was fetched from the API was being refreshed on every request to the dashboard, which added a significant overhead to loading task lists - especially when paginating.

Now the profile is only refreshed if caching is disabled - either in devtools or by force-refreshing, and is otherwise cached for 10 minutes.