### PR TITLE
Clone schema before modifying

### DIFF
--- a/pages/project-versions/submit/schema/index.js
+++ b/pages/project-versions/submit/schema/index.js
@@ -1,4 +1,4 @@
-const { omit, isEmpty } = require('lodash');
+const { omit, isEmpty, cloneDeep } = require('lodash');
 const content = require('../content');
 
 const conditionalRequired = (field, expected = 'Yes') => (value, model) => {
@@ -99,10 +99,10 @@ const schema = {
 
 const getSchema = type => {
   if (type === 'application') {
-    return omit(schema, 'comments');
+    return omit(cloneDeep(schema), 'comments');
   }
 
-  const amendmentSchema = omit(schema, 'ready');
+  const amendmentSchema = omit(cloneDeep(schema), 'ready');
   amendmentSchema.awerb.options[1] = {
     label: 'No',
     value: 'No',


### PR DESCRIPTION
Making changes to the schema leaves it permanently modified, so any amendment will permanently set the schema even for future applications.