### PR TITLE
Refactor profile cachebuster

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -68,10 +68,7 @@ module.exports = settings => {
     });
   });
 
-  app.use(cachebuster({
-    // don't invalidate profile cache on a project version update
-    whitelist: [ urls.project.version.update ]
-  }));
+  app.use(cachebuster());
 
   app.use(urls.dashboard, dashboard());
 

--- a/lib/middleware/profile-cachebuster.js
+++ b/lib/middleware/profile-cachebuster.js
@@ -1,9 +1,16 @@
-module.exports = ({ whitelist = [] }) => {
+module.exports = () => {
 
   return (req, res, next) => {
-    // destroy the profile cache if updating data
-    if (req.method !== 'get' && whitelist.includes(req.path)) {
-      req.session.profile = null;
+    const method = req.method.toLowerCase();
+    // if request is a get and the profile is stale then refresh it
+    if (method === 'get' && req.session.profile.stale) {
+      return req.user.refreshProfile()
+        .then(() => next())
+        .catch(next);
+    }
+    // mark the profile cache as stale if updating data
+    if (method !== 'get') {
+      req.session.profile.stale = true;
     }
     next();
   };


### PR DESCRIPTION
Mark the profile cache as stale on any non-GET request, then refresh it on any GET where the profile is found to be stale.

This prevents repeated reloading on project edits, but ensures that loading a profile after making a change will always load a fresh version of the user profile.