### PR TITLE
Standardise establishment URLs

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -21,10 +21,14 @@ const urls = traverseRoutes(routes);
 module.exports = settings => {
   const app = router({ ...settings, views, urls });
 
+  app.use('/e', (req, res) => {
+    res.redirect(req.originalUrl.replace('/e', '/establishments'), 301);
+  });
+
   app.use((req, res, next) => {
     if (settings.internalUrl && get(req, 'user.profile.asruUser')) {
       req.session.destroy();
-      return res.redirect(settings.internalUrl);
+      return res.redirect(`${settings.internalUrl}${req.originalUrl}`);
     }
     next();
   });

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -15,27 +15,27 @@ module.exports = {
     router: pages.user
   },
   establishment: {
-    path: '/e/:establishmentId',
+    path: '/establishments/:establishmentId',
     breadcrumb: false,
     router: pages.establishment
   },
   profile: {
-    path: '/e/:establishmentId/people',
+    path: '/establishments/:establishmentId/people',
     breadcrumb: false,
     router: pages.profile
   },
   role: {
-    path: '/e/:establishmentId/people/:profileId/role',
+    path: '/establishments/:establishmentId/people/:profileId/role',
     breadcrumb: false,
     router: pages.role
   },
   project: {
-    path: '/e/:establishmentId/projects',
+    path: '/establishments/:establishmentId/projects',
     breadcrumb: false,
     router: pages.project
   },
   projectVersion: {
-    path: '/e/:establishmentId/projects/:projectId/versions/:versionId',
+    path: '/establishments/:establishmentId/projects/:projectId/versions/:versionId',
     breadcrumb: false,
     router: pages.projectVersion,
     routes: {
@@ -47,12 +47,12 @@ module.exports = {
     }
   },
   place: {
-    path: '/e/:establishmentId/places',
+    path: '/establishments/:establishmentId/places',
     breadcrumb: false,
     router: pages.place
   },
   pil: {
-    path: '/e/:establishmentId/people/:profileId/pil',
+    path: '/establishments/:establishmentId/people/:profileId/pil',
     breadcrumb: false,
     router: pages.pil
   },


### PR DESCRIPTION
Make the establishment prefix consistent between internal and external facing services. Also preserve URL path when redirecting from external to internal facing service.

This allows internal users to seamlessly follow links provided by external users.