### PR TITLE
Redirect user to read-only version if editing a "not draft"

### DIFF
--- a/pages/project-versions/update/index.js
+++ b/pages/project-versions/update/index.js
@@ -58,7 +58,13 @@ module.exports = settings => {
     };
     req.api(`/establishments/${req.establishmentId}/projects/${req.projectId}/project-versions/${req.version.id}/patch`, opts)
       .then(() => res.json({}))
-      .catch(next);
+      .catch(err => {
+        // if trying to edit an uneditable version then redirect
+        if (err.status === 400) {
+          return res.redirect(req.buildRoute('projectVersion.read'));
+        }
+        next(err);
+      });
   });
 
   app.use((req, res, next) => res.sendResponse());


### PR DESCRIPTION
If a user has a tab open with a draft in edit mode, then submits it elsewhere then the edits continue to fail with 400 statuses. Instead of just putting the user in a failure loop immediately redirect them to a readonly version of their project.