### PR TITLE
Add page for a user's own profile

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -3,6 +3,7 @@ const { pages } = require('@asl/pages');
 const dashboard = require('../pages/dashboard');
 const invitation = require('../pages/invitation');
 const updateVersion = require('../pages/project-versions');
+const globalProfile = require('../pages/profile');
 
 module.exports = {
   dashboard: {
@@ -23,6 +24,11 @@ module.exports = {
     path: '/establishments/:establishmentId/people',
     breadcrumb: false,
     router: pages.profile
+  },
+  globalProfile: {
+    path: '/profile/:profileId',
+    breadcrumb: false,
+    router: globalProfile
   },
   role: {
     path: '/establishments/:establishmentId/people/:profileId/role',

--- a/pages/profile/content/index.js
+++ b/pages/profile/content/index.js
@@ -1,0 +1,14 @@
+const { merge } = require('lodash');
+const profileContent = require('@asl/pages/pages/profile/read/content');
+const pilContent = require('@asl/pages/pages/task/read/content/pil');
+
+module.exports = merge({}, pilContent, profileContent, {
+  establishment: {
+    link: 'About this establishment'
+  },
+  pil: {
+    training: {
+      title: 'Training'
+    }
+  }
+});

--- a/pages/profile/index.js
+++ b/pages/profile/index.js
@@ -1,0 +1,24 @@
+const { page } = require('@asl/service/ui');
+const { NotFoundError } = require('@asl/service/errors');
+
+module.exports = settings => {
+  const app = page({
+    ...settings,
+    root: __dirname
+  });
+
+  app.get('/', (req, res, next) => {
+    req.breadcrumb('profile.read');
+
+    if (req.user.profile.id !== req.profileId) {
+      return next(new NotFoundError());
+    }
+
+    res.locals.static.profile = req.user.profile;
+    next();
+  });
+
+  app.get('/', (req, res) => res.sendResponse());
+
+  return app;
+};

--- a/pages/profile/views/index.jsx
+++ b/pages/profile/views/index.jsx
@@ -1,0 +1,62 @@
+import React, { Fragment } from 'react';
+import { useSelector } from 'react-redux';
+import sortBy from 'lodash/sortBy';
+import { Header, PanelList, Link, ExpandingPanel, Snippet } from '@asl/components';
+
+import dateFormatter from 'date-fns/format';
+import { dateFormat } from '@asl/pages/constants';
+
+import Profile from '@asl/pages/pages/profile/read/views/profile';
+import Modules from '@asl/pages/pages/profile/read/views/modules';
+
+const formatDate = (date, format) => (date ? dateFormatter(date, format) : '-');
+
+export default function Index() {
+
+  const { profile } = useSelector(state => state.static);
+
+  const hasEstablishments = !!profile.establishments.length;
+
+  return <Fragment>
+    <Header title={`${profile.firstName} ${profile.lastName}`} />
+    <dl>
+      <dt>Email:</dt>
+      <dd><a href={`mailto:${profile.email}`}>{ profile.email }</a> | <Link page="account.updateEmail" label="Edit" /></dd>
+      {
+        profile.telephone && <Fragment>
+          <dt>Telephone:</dt>
+          <dd>{ profile.telephone } | <Link page="account.update" label="Edit" /></dd>
+        </Fragment>
+      }
+      {
+        profile.dob && <Fragment>
+          <dt>Date of birth:</dt>
+          <dd>{ formatDate(profile.dob, dateFormat.medium) } | <Link page="account.update" label="Edit" /></dd>
+        </Fragment>
+      }
+    </dl>
+    <h2><Snippet>pil.training.title</Snippet></h2>
+    {
+      profile.certificates && profile.certificates.length > 0
+        ? <Modules certificates={profile.certificates} />
+        : <p><em><Snippet>pil.training.none</Snippet></em></p>
+    }
+
+    {
+      hasEstablishments && <Fragment>
+        <h2>Establishments</h2>
+        <PanelList panels={sortBy(profile.establishments, 'name').map((establishment) => {
+          return (
+            <ExpandingPanel key={establishment.id} title={establishment.name} isOpen={profile.establishments.length === 1}>
+              <p>
+                <Link page="establishment.dashboard" establishmentId={establishment.id} label={<Snippet>establishment.link</Snippet>} />
+              </p>
+              <Profile establishment={establishment} profile={profile} allowedActions={profile.allowedActions[establishment.id]} />
+            </ExpandingPanel>
+          );
+        })} />
+      </Fragment>
+    }
+  </Fragment>;
+
+}


### PR DESCRIPTION
Allows displaying links to a user's profile in non-establishment scoped context, such as profile edit tasks.

Content taken from internal version of the same thing, but with some ASRU specific content removed.