### PR TITLE
Use Form component instead of raw <form> in accept invitation page

### DIFF
--- a/pages/invitation/views/index.jsx
+++ b/pages/invitation/views/index.jsx
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
-import { Inset, Snippet, Header } from '@asl/components';
+import { Inset, Snippet, Header, Form } from '@asl/components';
 import { Button } from '@ukhomeoffice/react-components';
 
 const Accept = ({ establishment }) => {
@@ -9,9 +9,9 @@ const Accept = ({ establishment }) => {
     <Inset>
       <Snippet>preamble</Snippet>
     </Inset>
-    <form method="post" action="">
+    <Form submit={false}>
       <Button type="submit"><Snippet>accept</Snippet></Button>
-    </form>
+    </Form>
   </Fragment>;
 };
 


### PR DESCRIPTION
This provides double-click protection and so reduces the number of errors in the logs caused by people double-accepting the invitation.

It also reduces the probability of a person's first interaction with the service being an error.