### PR TITLE
Return a new list of changes on project version updates

### DIFF
--- a/pages/project-versions/update/index.js
+++ b/pages/project-versions/update/index.js
@@ -2,6 +2,7 @@ const { page } = require('@asl/service/ui');
 const bodyParser = require('body-parser');
 const { get } = require('lodash');
 const {
+  getVersion,
   canComment,
   getAllChanges,
   getProjectEstablishment,
@@ -14,14 +15,14 @@ module.exports = settings => {
     root: __dirname
   });
 
-  app.use(
+  app.get('/',
     canComment(),
     getAllChanges(),
     getProjectEstablishment(),
     getPreviousProtocols()
   );
 
-  app.use((req, res, next) => {
+  app.get('/', (req, res, next) => {
     const isAmendment = req.project.status !== 'inactive';
     if (isAmendment) {
       req.breadcrumb('projectVersion.update');
@@ -57,7 +58,7 @@ module.exports = settings => {
       }
     };
     req.api(`/establishments/${req.establishmentId}/projects/${req.projectId}/project-versions/${req.version.id}/patch`, opts)
-      .then(() => res.json({}))
+      .then(() => next())
       .catch(err => {
         // if trying to edit an uneditable version then redirect
         if (err.status === 400) {
@@ -65,6 +66,10 @@ module.exports = settings => {
         }
         next(err);
       });
+  });
+
+  app.put('/', getVersion(), getAllChanges(), (req, res) => {
+    res.json({ changes: res.locals.static.changes });
   });
 
   app.use((req, res, next) => res.sendResponse());


### PR DESCRIPTION
This allows the UI to refresh the changed indicators if a change to one field has side effects in other parts of the application.

Also avoid doing loads of unnecessary loading of data on PUT operations by scoping all of the loading to only GET methods.

~Note: this is useless without https://github.com/UKHomeOffice/asl-projects/pull/502 being included so WIP-ed it until it has those changes.~

Edit: dependent projects PR is merged