### PR TITLE
CSS was moved to asl-projects

### DIFF
--- a/assets/sass/app.scss
+++ b/assets/sass/app.scss
@@ -8,12 +8,6 @@ h3 {
   margin-bottom: $govuk-gutter-half;
 }
 
-#ppl-drafting-tool .banner {
-  h2, h1 {
-    color: $white;
-  }
-}
-
 .page-header {
   margin-bottom: $govuk-gutter;
 }


### PR DESCRIPTION
This styling was required on internal UI also, so it was moved to projects.