### PR TITLE
remove redundant broken sass

### DIFF
--- a/assets/sass/app.scss
+++ b/assets/sass/app.scss
@@ -1,9 +1,6 @@
 @import "@asl/pages";
 @import "@asl/projects";
 
-$govuk-gutter: '20px';
-$govuk-gutter-half: '20px';
-
 @media (min-width: 1260px) {
   .govuk-width-container,
   .wrapper-header,


### PR DESCRIPTION
These were broken because of the quotes around the pixel values, but we inherit these constants from the imports anyway.

This may have unintended consequences to margins now that the values are correct - I'll have a browse around and make sure nothing is amiss.