### PR TITLE
Add custom phase banner content with link to RoPs survey

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -3,6 +3,9 @@ const { router, mountRoutes } = require('@asl/service/ui');
 const { views, content } = require('@asl/pages');
 const { get, mapValues } = require('lodash');
 
+const React = require('react');
+const PhaseBanner = require('./components/phase-banner').default;
+
 const cachebuster = require('./middleware/profile-cachebuster');
 
 const routes = require('./routes');
@@ -78,7 +81,11 @@ module.exports = settings => {
   app.use(cachebuster());
 
   app.use((req, res, next) => {
-    res.locals.phaseBannerSurvey = false;
+    // override the default phase banenr with ROPs survey content
+    res.locals.phaseBanner = {
+      phase: 'new survey',
+      content: React.createElement(PhaseBanner)
+    };
     res.locals.contactUsLink = true;
     next();
   });

--- a/lib/components/phase-banner.jsx
+++ b/lib/components/phase-banner.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const PhaseBanner = () => <span><a href="https://www.homeofficesurveys.homeoffice.gov.uk/s/U8PEWV/" rel="noopener noreferrer" target="_blank">Give feedback on the 2020 return of procedures process</a> so we can improve it next year.</span>;
+
+export default PhaseBanner;

--- a/package-lock.json
+++ b/package-lock.json
@@ -171,9 +171,9 @@
       }
     },
     "@asl/service": {
-      "version": "8.6.3",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/service/-/@asl/service-8.6.3.tgz",
-      "integrity": "sha1-0rqGshOLDkw1l2AZAuwHfdt7ITo=",
+      "version": "8.7.0",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/service/-/@asl/service-8.7.0.tgz",
+      "integrity": "sha1-Cx9DP/y37OgRefqeSQc0yDKXX5o=",
       "requires": {
         "@asl/components": "^8.0.0",
         "@babel/core": "^7.4.4",
@@ -10824,9 +10824,9 @@
       }
     },
     "redis-commands": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.6.0.tgz",
-      "integrity": "sha512-2jnZ0IkjZxvguITjFTrGiLyzQZcTvaw8DAaCXxZq/dsHXz7KfMQ3OUJy7Tz9vnRtZRVz6VRCPDvruvU8Ts44wQ=="
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
     },
     "redis-parser": {
       "version": "2.6.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@asl/components": "^9.0.1",
     "@asl/pages": "^24.4.0",
     "@asl/projects": "^9.3.3",
-    "@asl/service": "^8.6.3",
+    "@asl/service": "^8.7.0",
     "@babel/plugin-proposal-object-rest-spread": "^7.3.2",
     "@babel/preset-env": "^7.3.1",
     "@babel/preset-react": "^7.0.0",


### PR DESCRIPTION
Defines a local override of the default phase banner content to include link to RoPs survey.

Dependent on https://github.com/UKHomeOffice/asl-service/pull/216