### PR TITLE
Use secrets to pass npm credentials in `docker build`

### DIFF
--- a/.drone-1.0.yml
+++ b/.drone-1.0.yml
@@ -4,7 +4,7 @@ name: default
 type: kubernetes
 steps:
   - name: install
-    image: node:12
+    image: node:14
     environment:
       NPM_AUTH_USERNAME:
         from_secret: npm_auth_username
@@ -13,7 +13,7 @@ steps:
     commands:
       - npm ci
   - name: test
-    image: node:12
+    image: node:14
     environment:
       NPM_AUTH_USERNAME:
         from_secret: npm_auth_username
@@ -22,7 +22,7 @@ steps:
     commands:
       - npm test
   - name: audit
-    image: node:12
+    image: node:14
     environment:
       NPM_AUTH_USERNAME:
         from_secret: npm_auth_username
@@ -31,7 +31,7 @@ steps:
     commands:
       - npm audit --audit-level=high --production
   - name: compile
-    image: node:12
+    image: node:14
     environment:
       NPM_AUTH_USERNAME:
         from_secret: npm_auth_username
@@ -43,12 +43,13 @@ steps:
     image: docker:dind
     environment:
       DOCKER_HOST: tcp://docker:2375
+      DOCKER_BUILDKIT: 1
       NPM_AUTH_USERNAME:
         from_secret: npm_auth_username
       NPM_AUTH_TOKEN:
         from_secret: npm_auth_token
     commands:
-      - docker build --build-arg NPM_AUTH_USERNAME=$${NPM_AUTH_USERNAME} --build-arg NPM_AUTH_TOKEN=$${NPM_AUTH_TOKEN} -t asl .
+      - docker build --secret id=username,env=NPM_AUTH_USERNAME --secret id=token,env=NPM_AUTH_TOKEN -t asl .
   - name: docker push
     image: docker:dind
     environment:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,24 @@
-FROM quay.io/ukhomeofficedigital/asl-base:v12
+# syntax=docker/dockerfile:1.2
 
-ARG NPM_AUTH_USERNAME
-ARG NPM_AUTH_TOKEN
+FROM quay.io/ukhomeofficedigital/asl-base:v14
 
 RUN apk upgrade --no-cache
-
-USER 999
 
 COPY .npmrc /app/.npmrc
 COPY package.json /app/package.json
 COPY package-lock.json /app/package-lock.json
-RUN npm ci --production --no-optional --ignore-scripts
+
+RUN --mount=type=secret,id=token \
+    --mount=type=secret,id=username \
+    NPM_AUTH_USERNAME=`cat /run/secrets/username` \
+    NPM_AUTH_TOKEN=`cat /run/secrets/token` \
+    npm ci --production --no-optional --ignore-scripts
+
 COPY . /app
 
 RUN rm /app/.npmrc
+
+USER 999
 
 # prime the babel cache at build time to improve deployed startup time
 RUN node lib/app.js


### PR DESCRIPTION
`--build-args` are not secure because they leave the argument value in logs.