### PR TITLE
Throw error if API endpoint is not defined

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -19,6 +19,13 @@ function traverseRoutes(routes) {
 const urls = traverseRoutes(routes);
 
 module.exports = settings => {
+  if (!settings.api) {
+    throw new Error('API_URL endpoint must be defined');
+  }
+  if (!settings.auth.permissions) {
+    throw new Error('PERMISSIONS_SERVICE endpoint must be defined');
+  }
+
   const app = router({ ...settings, views, urls });
 
   app.use('/e', (req, res) => {


### PR DESCRIPTION
It's fundamental to the UI to have the API present, so if it's not there then throw, and make setting up local development a whole lot easier because the error doesn't reappear as something completely different a few steps down the road.