### PR TITLE
Handle failed alerts API call in UI

### DIFF
--- a/pages/dashboard/views/dashboard-alerts.jsx
+++ b/pages/dashboard/views/dashboard-alerts.jsx
@@ -75,6 +75,11 @@ function EstablishmentAlert({ name, summary }) {
 export default function DashboardAlerts() {
   const { alerts } = useSelector(state => state.static);
 
+  // if the alerts API call failed then don't crash the dashboard
+  if (!alerts) {
+    return null;
+  }
+
   return (
     <div className="dashboard-alerts">
       {


### PR DESCRIPTION
If the API call to fetch alerts fails then the [server code allows the dashboard to continue rendering without alerts](https://github.com/UKHomeOffice/asl/blob/master/pages/dashboard/index.js#L129), but then the component throws an error so the dashboard render fails anyway.

Check that the alerts are set before trying to render to allow a graceful failure.