### PR TITLE
Add status badges to dashboard establishment panels

### DIFF
--- a/pages/dashboard/views/index.jsx
+++ b/pages/dashboard/views/index.jsx
@@ -21,10 +21,14 @@ const Invitation = ({ token, establishment }) => (
 );
 
 const EstablishmentPanel = ({ establishment, profile }) => {
+  if (establishment.suspendedDate) {
+    establishment.status = 'suspended';
+  }
   const title = <h3>
     {establishment.name}
-    { establishment.status === 'inactive' && <span className="status-notice">(draft - establishment not yet licensed)</span> }
-    { establishment.status === 'revoked' && <span className="status-notice">(revoked - establishment no longer licensed)</span> }
+    { establishment.status === 'inactive' && <span className="status-notice"><span className="badge">draft</span> establishment not yet licensed</span> }
+    { establishment.status === 'revoked' && <span className="status-notice"><span className="badge rejected">revoked</span> establishment no longer licensed</span> }
+    { establishment.status === 'suspended' && <span className="status-notice"><span className="badge rejected">suspended</span></span> }
   </h3>;
 
   return (


### PR DESCRIPTION
Make it _a lot_ clearer to users if any of their establishments are not currently active.

<img width="1240" alt="Screenshot 2022-09-08 at 15 58 20" src="https://user-images.githubusercontent.com/117398/189156020-84fc9411-3814-4512-abbc-944cc87abc6a.png">
