### PR TITLE
Update token reference in drone yaml

### DIFF
--- a/.drone-1.0.yml
+++ b/.drone-1.0.yml
@@ -78,7 +78,7 @@ steps:
       GITHUB_AUTH_TOKEN:
         from_secret: github_token
       GITHUB_ACCESS_TOKEN:
-        from_secret: github_access_token
+        from_secret: github_auth_token
     commands:
       - update
         --repo ukhomeoffice/asl-deployments


### PR DESCRIPTION
Looks like there has been a mixup of github tokens in drone, github_access_token is not set as a secret, trying to see if auth token is the one we need